### PR TITLE
Add variable type and content validations

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,6 +8,6 @@ fixtures:
       ref: 'v1.4.0'
     nfs:
       repo: 'git://github.com/ghoneycutt/puppet-module-nfs.git'
-      ref: 'v1.11.0'
+      ref: 'v1.11.3'
   symlinks:
     nfsclient: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,15 @@ env:
     - PUPPET_GEM_VERSION="~> 3.6.0"
     - PUPPET_GEM_VERSION="~> 3.7.0"
     - PUPPET_GEM_VERSION="~> 3.8.0"
-    - PUPPET_GEM_VERSION="~> 3" PARSER="future"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
     - PUPPET_GEM_VERSION="~> 4.0.0"
     - PUPPET_GEM_VERSION="~> 4.1.0"
     - PUPPET_GEM_VERSION="~> 4.2.0"
     - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
     - PUPPET_GEM_VERSION="~> 4"
+    - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 sudo: false
 
@@ -50,7 +53,13 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.3.0"
     - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.5.0"
+    - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 notifications:
   email: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,9 @@ class nfsclient (
       $gss_line    = 'NFS_SECURITY_GSS'
       $keytab_line = 'GSSD_OPTIONS'
       $service     = 'nfs'
+      # Setting nfs_requires to undef just fixes the code
+      # Someone with better functional knowledge should fix functionality if needed or remove this comment.
+      $nfs_requires = undef
       if $::operatingsystemrelease =~ /^11/ {
         if $gss_real {
           file_line { 'NFS_START_SERVICES':

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
     },
     {
       "name": "ghoneycutt/nfs",
-      "version_requirement": ">= 1.11.0"
+      "version_requirement": ">= 1.11.3"
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -200,4 +200,57 @@ describe 'nfsclient' do
       should compile.and_raise_error(/nfsclient module only supports Suse and RedHat. <UNSUPPORTED> was detected./)
     end
   end
+
+  describe 'variable type and content validations' do
+    # set needed custom facts and variables
+    let(:facts) do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystemrelease    => '7.2',
+        :operatingsystemmajrelease => '7',
+      }
+    end
+    let(:mandatory_params) do
+      {
+        #:param => 'value',
+      }
+    end
+
+    validations = {
+      'absolute_path' => {
+        :name    => %w(keytab),
+        :valid   => ['/absolute/filepath','/absolute/directory/'],
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
+        :message => 'is not an absolute path',
+      },
+      'boolean_stringified' => {
+        :name    => %w(gss),
+        :valid   => [true, false, 'true', 'false'],
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, nil],
+        :message => 'str2bool',
+      },
+    }
+
+    validations.sort.each do |type, var|
+      var[:name].each do |var_name|
+        var[:params] = {} if var[:params].nil?
+        var[:valid].each do |valid|
+          context "when #{var_name} (#{type}) is set to valid #{valid} (as #{valid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => valid, }].reduce(:merge) }
+            it { should compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "when #{var_name} (#{type}) is set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => invalid, }].reduce(:merge) }
+            it 'should fail' do
+              expect { should contain_class(subject) }.to raise_error(Puppet::Error, /#{var[:message]}/)
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
+
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,12 +10,12 @@ describe 'nfsclient' do
 
   let :options do
     {
-      'gss' =>
+      'gss_line' =>
         {
           'RedHat' => 'SECURE_NFS',
           'Suse' => 'NFS_SECURITY_GSS',
         },
-      'keytab' =>
+      'keytab_line' =>
         {
           'RedHat' => 'RPCGSSDARGS',
           'Suse' => 'GSSD_OPTIONS',
@@ -43,8 +43,8 @@ describe 'nfsclient' do
           should contain_file_line('NFS_SECURITY_GSS').with(
           {
             'path' => '/etc/sysconfig/nfs',
-            'line' => "#{options['gss'][facts[:osfamily]]}=\"yes\"",
-            'match' => "^#{options['gss'][facts[:osfamily]]}=.*",
+            'line' => "#{options['gss_line'][facts[:osfamily]]}=\"yes\"",
+            'match' => "^#{options['gss_line'][facts[:osfamily]]}=.*",
           })
           should contain_file_line('NFS_SECURITY_GSS').that_notifies('Service[rpcbind_service]')
           should contain_class('rpcbind')
@@ -56,8 +56,8 @@ describe 'nfsclient' do
           should contain_file_line('GSSD_OPTIONS').with(
           {
             'path' => '/etc/sysconfig/nfs',
-            'line' => "#{options['keytab'][facts[:osfamily]]}=\"-k /etc/keytab\"",
-            'match' => "^#{options['keytab'][facts[:osfamily]]}=.*",
+            'line' => "#{options['keytab_line'][facts[:osfamily]]}=\"-k /etc/keytab\"",
+            'match' => "^#{options['keytab_line'][facts[:osfamily]]}=.*",
           })
           should contain_file_line('GSSD_OPTIONS').that_notifies('Service[rpcbind_service]')
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,3 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
-
-RSpec.configure do |config|
-  config.before :each do
-    Puppet[:parser] = 'future' if ENV['PARSER'] == 'future'
-  end
-end


### PR DESCRIPTION
- fix dependency issues when $gss or $keytab is set on its own

Found this dependency issue while adding the variable type/content checks.
When only one parameter is set, hard coded dependencies did not match.
